### PR TITLE
Copy constructor and assignement operator overload for phenotype

### DIFF
--- a/core/PhysiCell_phenotype.cpp
+++ b/core/PhysiCell_phenotype.cpp
@@ -1058,10 +1058,46 @@ Phenotype::Phenotype()
 	flagged_for_removal = false; 
 	
 	// sync the molecular stuff here automatically? 
+	intracellular = NULL;
 	
 	return; 
 }
 
+Phenotype::Phenotype(const Phenotype &p) {
+	intracellular = NULL;
+	*this = p;
+}
+
+Phenotype::~Phenotype() 
+{
+	if (intracellular != NULL)
+		delete intracellular;
+}
+
+Phenotype& Phenotype::operator=(const Phenotype &p ) { 
+		
+	flagged_for_division = p.flagged_for_division;
+	flagged_for_removal = p.flagged_for_removal;
+	
+	cycle = p.cycle;
+	death = p.death;
+	volume = p.volume;
+	geometry = p.geometry;
+	mechanics = p.mechanics;
+	motility = p.motility;
+	secretion = p.secretion;
+	
+	molecular = p.molecular;
+	
+	delete intracellular;
+	
+	if (p.intracellular != NULL)
+		intracellular = p.intracellular->clone();
+	else
+		intracellular = NULL;
+	
+	return *this;
+}
 /*
 class Bools
 {

--- a/core/PhysiCell_phenotype.h
+++ b/core/PhysiCell_phenotype.h
@@ -620,7 +620,10 @@ class Phenotype
 	Intracellular* intracellular;
 	
 	Phenotype(); // done 
-	
+	Phenotype(const Phenotype &p);
+	~Phenotype();
+	Phenotype& operator=(const Phenotype &p );
+
 	void sync_to_functions( Cell_Functions& functions ); // done 
 	
 	void sync_to_microenvironment( Microenvironment* pMicroenvironment ); 


### PR DESCRIPTION
Added copy constructor and assignement operator overload for phenotype, which takes care of creating and initializing the intracellular object